### PR TITLE
fix: add dnspython to requirements due to mongodb srv dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ flask_testing==0.8.1
 black==21.6b0
 urllib3==1.23
 requests==2.19.0
+dnspython==2.1.0


### PR DESCRIPTION
## Changes
- [X] Added `dnspython==2.1.0` to `requirements.txt` because of error message `pymongo.errors.ConfigurationError: The "dnspython" module must be installed to use mongodb+srv:// URIs`