### PR TITLE
feat: implement hashtag CRUD procedure in MongoDB

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from src.contact import ContactForm
 from src.course import Course, CourseList
 from src.department import Department, DepartmentList
 from src.seat import Seat, SeatList
+from src.miscellaneous import Hashtag
 import flask_restful
 
 app = Flask(__name__)
@@ -26,6 +27,7 @@ api.add_resource(Department, "/department")
 api.add_resource(DepartmentList, "/department_list")
 api.add_resource(SeatList, "/seat_list")
 api.add_resource(Seat, "/seat")
+api.add_resource(Hashtag, "/hashtag")
 
 # Load envvironmental variables in .env
 load_dotenv(find_dotenv())

--- a/src/miscellaneous.py
+++ b/src/miscellaneous.py
@@ -1,0 +1,154 @@
+import sys, json
+
+sys.path.append("..")
+from app import *
+from src.util import *
+from flask import Flask, abort, request, jsonify, render_template
+from flask_restful import reqparse, abort, Api, Resource
+from bson.json_util import dumps, loads
+
+parser = reqparse.RequestParser()
+parser.add_argument("tag")
+parser.add_argument("display")
+
+
+class Hashtag(Resource):
+    def get(self):
+        """Gets the hastag list.
+
+        Returns:
+            A list of hashtag details
+
+        Example:
+        [
+            {
+                "name": "example_tag_1",
+                "is_display": 1
+            },
+            {
+                "name": "example_tag_2",
+                "is_display": 1
+            },
+            {
+                "name": "example_tag_3",
+                "is_display": 0
+            }
+        ]
+        """
+        request.get_json()
+        args = parser.parse_args()
+        print(args)
+        if args["display"] and args["tag"]:
+            abort_invalid_input(
+                "Invalid Input(400): Please check you input parameters!"
+            )
+        db = get_db(db_name="miscellaneous")
+        coll = db["hashtag"]
+        if args["tag"]:
+            cursor = coll.find({"name": str(args["tag"])})
+        elif args["display"]:
+            cursor = coll.find({"is_display": str(args["display"])})
+        else:
+            cursor = coll.find()
+        res = []
+        for tag in cursor:
+            res.append({"name": tag["name"], "is_display": tag["is_display"]})
+        return res
+
+    def post(self):
+        """Adds a tag into hashtag list.
+
+        Args(from request body):
+            tag: tag name
+            display: display status (default 1)
+        Returns:
+            Post result or error
+        """
+        request.get_json()
+        args = parser.parse_args()
+        try:
+            tag = str(args["tag"])
+            if "display" not in args:
+                is_display = 1
+            else:
+                is_display = int(args["display"])
+        except:
+            abort_invalid_input(
+                "Invalid Input(400): Please check you input parameters!"
+            )
+        db = get_db(db_name="miscellaneous")
+        coll = db["hashtag"]
+        try:
+            insert_tag = {"name": tag, "is_display": is_display}
+            if coll.find_one({"name": tag}):
+                abort_invalid_input(
+                    "Invalid Input(400): Cannot insert tag already in DB"
+                )
+            result = coll.update_one(
+                filter={"name": tag}, update={"$set": insert_tag}, upsert=True
+            )
+        except Exception as e:
+            abort_not_found(str(e))
+        return (
+            str(result.upserted_id)
+            if result.upserted_id
+            else "400, Unable to POST to MongoDB"
+        )
+
+    def put(self):
+        """Updates a tag into hashtag list.
+
+        Args(from request body):
+            tag: tag name
+            display: display status
+        Returns:
+            PUT result
+        """
+        request.get_json()
+        args = parser.parse_args()
+        try:
+            tag = str(args["tag"])
+            is_display = int(args["display"])
+        except:
+            abort_invalid_input(
+                "Invalid Input(400): Please check you input parameters!"
+            )
+        db = get_db(db_name="miscellaneous")
+        coll = db["hashtag"]
+        try:
+            update_tag = {"name": tag, "is_display": is_display}
+            result = coll.update_one(
+                filter={"name": tag}, update={"$set": update_tag}, upsert=False
+            )
+        except Exception as e:
+            abort_not_found(str(e))
+        if result.modified_count > 0:
+            return "200, Successful"
+        elif result.upserted_id != None:
+            return "200, Inserted new tag"
+        else:
+            return "400, Did not update"
+
+    def delete(self):
+        """Deletes a tag from hashtag list.
+
+        Args(from request body):
+            tag: tag name
+        Returns:
+            Post result or error
+        """
+        request.get_json()
+        args = parser.parse_args()
+        try:
+            tag = str(args["tag"])
+        except:
+            abort_invalid_input(
+                "Invalid Input(400): Please check you input parameters!"
+            )
+        db = get_db(db_name="miscellaneous")
+        coll = db["hashtag"]
+        try:
+            result = coll.delete_one({"name": tag})
+        except Exception as e:
+            abort_not_found(str(e))
+        return "Success" if result.deleted_count == 1 else "Unable to delete!"

--- a/src/miscellaneous.py
+++ b/src/miscellaneous.py
@@ -16,6 +16,9 @@ class Hashtag(Resource):
     def get(self):
         """Gets the hastag list.
 
+        Args(from request body):
+            tag: tag name
+            display: display status (default 1)
         Returns:
             A list of hashtag details
 
@@ -37,7 +40,6 @@ class Hashtag(Resource):
         """
         request.get_json()
         args = parser.parse_args()
-        print(args)
         if args["display"] and args["tag"]:
             abort_invalid_input(
                 "Invalid Input(400): Please check you input parameters!"
@@ -47,7 +49,7 @@ class Hashtag(Resource):
         if args["tag"]:
             cursor = coll.find({"name": str(args["tag"])})
         elif args["display"]:
-            cursor = coll.find({"is_display": str(args["display"])})
+            cursor = coll.find({"is_display": int(args["display"])})
         else:
             cursor = coll.find()
         res = []
@@ -67,8 +69,10 @@ class Hashtag(Resource):
         request.get_json()
         args = parser.parse_args()
         try:
+            if not args["tag"]:
+                raise Exception("Tag name is not in argument list")
             tag = str(args["tag"])
-            if "display" not in args:
+            if not args["display"]:
                 is_display = 1
             else:
                 is_display = int(args["display"])

--- a/src/util.py
+++ b/src/util.py
@@ -1,5 +1,5 @@
-import os
-from flask import Flask, abort, request, jsonify, render_template
+import os, json
+from flask import Flask, abort, request, jsonify, render_template, make_response
 from flask_restful import reqparse, abort, Api, Resource
 from pymongo import MongoClient
 from pymongo import errors as mongoerrors
@@ -51,6 +51,22 @@ def get_quarter_collections(year, quarter, collection_type):
             ),
         )
     return coll
+
+
+def generate_response(data, code, headers=None):
+    """Makes a Flask response with a JSON encoded body
+
+    Args:
+        data: the data to be responded
+        code: the status code in the response
+        header: the optional header to be responeded
+    Returns:
+        Generated response body in JSON format
+
+    """
+    resp = make_response(json.dumps(data), code)
+    resp.headers.extend(headers or {})
+    return resp
 
 
 def abort_if_course_doesnt_exist(course_id, courses, year=None, quarter=None):
@@ -130,9 +146,9 @@ def abort_if_email_doesnt_exist(email, forms):
 
 def abort_invalid_input(err_message):
     """Send an error message 400."""
-    abort(400, message=err_message)
+    abort(http_status_code=400, message=err_message)
 
 
 def abort_not_found(err_message):
     """Send an error message 404."""
-    abort(404, message=err_message)
+    abort(http_status_code=404, message=err_message)

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -1,8 +1,14 @@
 import requests
 import unittest
 import urllib
+import json
+import time
+import multiprocessing
+import pytest
 from flask import Flask
 from flask_testing import LiveServerTestCase
+
+multiprocessing.set_start_method("fork")
 
 
 class BaseTest(LiveServerTestCase):
@@ -24,6 +30,64 @@ class BaseTest(LiveServerTestCase):
     def test_example_id_token_check(self):
         response = requests.get(self.get_server_url() + "/example_id_token_check")
         self.assertEqual(response.status_code, 403)
+
+    @pytest.mark.skip(reason="Only enable at local or on server, will add config later")
+    def test_example_hashtag(self):
+        example_hashtag = {"tag": "pytest_check", "display": 1}
+        requests.delete(self.get_server_url() + "/hashtag", data=example_hashtag)
+        try:
+            response = requests.post(
+                self.get_server_url() + "/hashtag", data=example_hashtag
+            )
+            self.assertEqual(response.status_code, 200)
+
+            time.sleep(0.5)
+            response = requests.get(
+                self.get_server_url() + "/hashtag", data={"tag": "pytest_check"}
+            )
+            self.assertEqual(response.status_code, 200)
+            response_content = json.loads(response.content)
+            self.assertEqual(response_content[0]["name"], example_hashtag["tag"])
+            self.assertEqual(
+                response_content[0]["is_display"], example_hashtag["display"]
+            )
+
+            time.sleep(0.5)
+            response = requests.get(
+                self.get_server_url() + "/hashtag",
+                data={"tag": "this_is_a_tag_that_does_not_exist!"},
+            )
+            self.assertEqual(response.status_code, 404)
+
+            time.sleep(0.5)
+            response = requests.put(
+                self.get_server_url() + "/hashtag",
+                data={"tag": "pytest_check", "display": 0},
+            )
+            self.assertEqual(response.status_code, 200)
+
+            time.sleep(0.5)
+            response = requests.get(
+                self.get_server_url() + "/hashtag", data={"tag": "pytest_check"}
+            )
+            self.assertEqual(response.status_code, 200)
+            response_content = json.loads(response.content)
+            self.assertEqual(response_content[0]["name"], example_hashtag["tag"])
+            self.assertEqual(response_content[0]["is_display"], 0)
+
+            time.sleep(0.5)
+            response = requests.delete(
+                self.get_server_url() + "/hashtag", data={"tag": "pytest_check"}
+            )
+            self.assertEqual(response.status_code, 200)
+
+            response = requests.get(
+                self.get_server_url() + "/hashtag", data={"tag": "pytest_check"}
+            )
+            self.assertEqual(response.status_code, 404)
+        except AssertionError as e:
+            requests.delete(self.get_server_url() + "/hashtag", data=example_hashtag)
+            pytest.fail(str(e))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes
Added hashtag in mongodb
- [X] GET: we can choose to get a list of all hashtags (`/hashtag`), getting the detail of a specific tagname (`/hashtag?tag=<tagname>`, probably to see if the `is_display` attribute is set or not), or getting a list of tags with `is_display` is set to 1 (`/hashtag?display=1`).
- [X] POST: we can add a new hashtag into the db using `/hashtag?tag=<tagname>&display=<0/1>`, this request cannot be used to update existing hashtags.
- [X] PUT: we can update an existing hashtag in the db using `/hashtag?tag=<tagname>&display=<0/1>`, this request cannot be used to insert new hashtags.
- [X] DELETE: we can delete a hashtag with specified tag name using `/hashtag?tag=<tagname>`