### PR TITLE
refactor: split hashtag test into different functions

### DIFF
--- a/tests/miscellaneous_test.py
+++ b/tests/miscellaneous_test.py
@@ -8,27 +8,29 @@ import urllib
 from flask import Flask
 from tests.app_test import BaseTest
 
-
 class MiscellaneousTest(BaseTest):
-    @pytest.mark.skip(reason="Only enable at local or on server, will add config later")
-    def test_example_hashtag(self):
-        example_hashtag = {"tag": "pytest_check", "display": 1}
-        requests.delete(self.get_server_url() + "/hashtag", data=example_hashtag)
+    example_hashtag = {"tag": "pytest_check", "display": 1}
+
+    def hashtag_post_test(self):
         try:
             response = requests.post(
-                self.get_server_url() + "/hashtag", data=example_hashtag
-            )
+                    self.get_server_url() + "/hashtag", data=self.example_hashtag
+                )
             self.assertEqual(response.status_code, 200)
-
-            time.sleep(0.5)
+        except AssertionError as e:
+            requests.delete(self.get_server_url() + "/hashtag", data=self.example_hashtag)
+            pytest.fail(str(e))
+        
+    def hashtag_get_test(self):
+        try:
             response = requests.get(
                 self.get_server_url() + "/hashtag", data={"tag": "pytest_check"}
             )
             self.assertEqual(response.status_code, 200)
             response_content = json.loads(response.content)
-            self.assertEqual(response_content[0]["name"], example_hashtag["tag"])
+            self.assertEqual(response_content[0]["name"], self.example_hashtag["tag"])
             self.assertEqual(
-                response_content[0]["is_display"], example_hashtag["display"]
+                response_content[0]["is_display"], self.example_hashtag["display"]
             )
 
             time.sleep(0.5)
@@ -37,8 +39,12 @@ class MiscellaneousTest(BaseTest):
                 data={"tag": "this_is_a_tag_that_does_not_exist!"},
             )
             self.assertEqual(response.status_code, 404)
+        except AssertionError as e:
+            requests.delete(self.get_server_url() + "/hashtag", data=self.example_hashtag)
+            pytest.fail(str(e))
 
-            time.sleep(0.5)
+    def hashtag_put_test(self):
+        try:
             response = requests.put(
                 self.get_server_url() + "/hashtag",
                 data={"tag": "pytest_check", "display": 0},
@@ -51,22 +57,33 @@ class MiscellaneousTest(BaseTest):
             )
             self.assertEqual(response.status_code, 200)
             response_content = json.loads(response.content)
-            self.assertEqual(response_content[0]["name"], example_hashtag["tag"])
+            self.assertEqual(response_content[0]["name"], self.example_hashtag["tag"])
             self.assertEqual(response_content[0]["is_display"], 0)
+        except AssertionError as e:
+            requests.delete(self.get_server_url() + "/hashtag", data=self.example_hashtag)
+            pytest.fail(str(e))
 
-            time.sleep(0.5)
+    def hashtag_delete_test(self):
+        try:
             response = requests.delete(
                 self.get_server_url() + "/hashtag", data={"tag": "pytest_check"}
             )
             self.assertEqual(response.status_code, 200)
-
             response = requests.get(
                 self.get_server_url() + "/hashtag", data={"tag": "pytest_check"}
             )
             self.assertEqual(response.status_code, 404)
         except AssertionError as e:
-            requests.delete(self.get_server_url() + "/hashtag", data=example_hashtag)
+            requests.delete(self.get_server_url() + "/hashtag", data=self.example_hashtag)
             pytest.fail(str(e))
+
+    @pytest.mark.skip(reason="Only enable at local or on server, will add config later")
+    def test_hashtag(self):
+        requests.delete(self.get_server_url() + "/hashtag", data=self.example_hashtag)
+        self.hashtag_post_test()
+        self.hashtag_get_test()
+        self.hashtag_put_test()
+        self.hashtag_delete_test()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes
- [X] Moved tests in `test_example_hashtag` into different functions, but there is still one single test function to call other functions, this is to ensure the tests are done in order and the later tests are dependent on the successful pass of previous tests.

Note: This PR closes #20 