### PR TITLE
feat: add util function for data models and enum table

### DIFF
--- a/src/data_models/article_model.py
+++ b/src/data_models/article_model.py
@@ -1,4 +1,7 @@
 from app import sql_db
+from src.data_models.enum_tables.degree_type import from_code_to_degree_type_name
+from src.data_models.enum_tables.school import from_code_to_school_name
+from src.data_models.enum_tables.major import from_code_to_major_name
 import datetime
 
 
@@ -27,3 +30,40 @@ class ArticleModel(sql_db.Model):
     degree_type = sql_db.Column(sql_db.Integer)
     is_spam = sql_db.Column(sql_db.Boolean, default=False, nullable=False)
     is_approved = sql_db.Column(sql_db.Boolean, default=False, nullable=False)
+
+    def to_dict(self):
+        """Convert current article to dictionary format.
+
+        Returns:
+            A dictionary that includes all columns and its values of
+            a article in the `article` table.
+        """
+        return {
+            "article_id": self.article_id,
+            "article_title": self.article_title,
+            "article_content": self.article_content,
+            "user_id": self.user_id,
+            "like_count": self.like_count,
+            "view_count": self.view_count,
+            "post_time": str(self.post_time),
+            "last_updated_time": str(self.last_updated_time),
+            "school_from": {
+                "school_code": self.school_from,
+                "name": from_code_to_school_name(self.school_from),
+            },
+            "school_to": {
+                "school_code": self.school_to,
+                "name": from_code_to_school_name(self.school_to),
+            },
+            "major": {
+                "major_code": self.major,
+                "name": from_code_to_major_name(self.major),
+            },
+            "graduate_year": self.graduate_year,
+            "degree_type": {
+                "degree_type_code": self.degree_type,
+                "name": from_code_to_degree_type_name(self.degree_type),
+            },
+            "is_spam": self.is_spam,
+            "is_approved": self.is_approved,
+        }

--- a/src/data_models/comment_model.py
+++ b/src/data_models/comment_model.py
@@ -21,6 +21,12 @@ class CommentModel(sql_db.Model):
     is_spam = sql_db.Column(sql_db.Boolean, default=False, nullable=False)
 
     def to_dict(self):
+        """Convert current comment to dictionary format.
+
+        Returns:
+            A dictionary that includes all columns and its values of
+            a comment in the `comment` table.
+        """
         return {
             "comment_id": self.comment_id,
             "comment_content": self.comment_content,

--- a/src/data_models/enum_tables/degree_type.py
+++ b/src/data_models/enum_tables/degree_type.py
@@ -1,0 +1,25 @@
+# A mapping from degree type code to degree type name.
+DEGREE_TYPE = {
+    # Todo: Add degree types here.
+    0: "UNKNOWN",
+    1: "Associate",
+    2: "Bachelor",
+    3: "Master",
+    4: "Ph.D.",
+    6: "Certification",
+    7: "Joint Degrees",
+    8: "Professional",
+}
+
+
+def from_code_to_degree_type_name(degree_type_code):
+    """Return the corresponding name of degree type.
+
+    Args:
+        int, the code of degree type
+    Returns:
+        str, the name of degree type
+    """
+    if degree_type_code not in DEGREE_TYPE:
+        return "UNKNOWN"
+    return DEGREE_TYPE[degree_type_code]

--- a/src/data_models/enum_tables/major.py
+++ b/src/data_models/enum_tables/major.py
@@ -1,0 +1,23 @@
+# A mapping from major code to major name.
+MAJOR = {
+    # Todo: Add major lists here.
+    0: "UNKNOWN",
+    1: "Mathematics",
+    2: "Statistics",
+    3: "Communication",
+    4: "Computer Science",
+    6: "Data Science",
+}
+
+
+def from_code_to_major_name(major_code):
+    """Return the corresponding name of major.
+
+    Args:
+        int, the code of major
+    Returns:
+        str, the name of major
+    """
+    if major_code not in MAJOR:
+        return "UNKNOWN"
+    return MAJOR[major_code]

--- a/src/data_models/enum_tables/school.py
+++ b/src/data_models/enum_tables/school.py
@@ -1,0 +1,28 @@
+# A mapping from school code to school name.
+SCHOOL = {
+    # Todo: Add school names here.
+    0: "UNKNOWN",
+    1: "University of California, Berkeley",
+    2: "University of California, Los Angeles",
+    3: "University of California, San Diego",
+    4: "University of California, Santa Barbara",
+    5: "University of California, Irvine",
+    6: "University of California, Davis",
+    7: "University of California, Riverside",
+    8: "University of California, Merced",
+    9: "University of California, San Francisco",
+    10: "De Anza College",
+}
+
+
+def from_code_to_school_name(school_code):
+    """Return the corresponding name of school.
+
+    Args:
+        int, the code of school
+    Returns:
+        str, the name of school
+    """
+    if school_code not in SCHOOL:
+        return "UNKNOWN"
+    return SCHOOL[school_code]

--- a/tests/data_models/enum_test.py
+++ b/tests/data_models/enum_test.py
@@ -1,0 +1,30 @@
+import sys
+
+sys.path.append("..")
+import unittest
+from src.data_models.enum_tables.degree_type import *
+from src.data_models.enum_tables.major import *
+from src.data_models.enum_tables.school import *
+
+
+class DataModelsEnumTest(unittest.TestCase):
+    def test_degree_type(self):
+        self.assertEqual(from_code_to_degree_type_name(0), "UNKNOWN")
+        self.assertEqual(from_code_to_degree_type_name(1000000), "UNKNOWN")
+        self.assertEqual(from_code_to_degree_type_name(8), "Professional")
+
+    def test_major(self):
+        self.assertEqual(from_code_to_major_name(0), "UNKNOWN")
+        self.assertEqual(from_code_to_major_name(50000000), "UNKNOWN")
+        self.assertEqual(from_code_to_major_name(6), "Data Science")
+
+    def test_school(self):
+        self.assertEqual(from_code_to_school_name(0), "UNKNOWN")
+        self.assertEqual(from_code_to_school_name(7958245), "UNKNOWN")
+        self.assertEqual(
+            from_code_to_school_name(9), "University of California, San Francisco"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes
- [x] Add util function for `ArticleModel` to convert article to dictionary 
- [x] Add initial enum table for major/school/degree. This will be used to convert major code/school code/degree code(int) to their names. Currently, the enum table is not finished. We will add more majors/schools/degrees to the table. 

## How Has This Been Tested?
- Passed `pytest` locally.
- Add unit tests for enum tables util function.
- I haven't tested ArticleModel.to_dict() function yet. Please help fix it if you encounter any errors @yifeili98 . Thanks!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules