### PR TITLE
fix: Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ dnspython==2.1.0
 python-dotenv==0.18.0
 pymysql==1.0.2
 SQLAlchemy==1.3.24
-Flask-SQLAlchemy==2.3.2
+Flask-SQLAlchemy==2.5.1


### PR DESCRIPTION
Update flask sqlalchemy version to 2.5.1 to fix the following issue:
```
AttributeError: module 'time' has no attribute 'clock' in Python 3.8
```